### PR TITLE
Fix cell reordering glitches by disabling UIFetchedResultsControllerDelegate.

### DIFF
--- a/Coffee Timer/Coffee Timer/TimerListTableViewController.swift
+++ b/Coffee Timer/Coffee Timer/TimerListTableViewController.swift
@@ -124,12 +124,16 @@ class TimerListTableViewController: UITableViewController {
 
         // The models are now in the correct order.
         // Update their displayOrder to match the new order.
+        print("Updating model")
         for i in 0..<objectsInSection.count {
             let model = objectsInSection[i] as? TimerModel
             model?.displayOrder = Int32(i)
         }
+        print("Finished updating model")
 
         userReorderingCells = false
+        
+        print("Saving managed object context.")
         appDelegate().coreDataStack.save()
     }
 
@@ -224,7 +228,10 @@ extension TimerListTableViewController: NSFetchedResultsControllerDelegate {
 
     func controller(controller: NSFetchedResultsController, didChangeObject anObject: AnyObject, atIndexPath indexPath: NSIndexPath?, forChangeType type: NSFetchedResultsChangeType, newIndexPath: NSIndexPath?) {
 
-        guard userReorderingCells == false else { return }
+        guard userReorderingCells == false else { 
+            print("Controller did change object, but user reordering cells: skipping.")
+            return
+        }
 
         switch type {
         case .Insert:
@@ -232,6 +239,7 @@ extension TimerListTableViewController: NSFetchedResultsControllerDelegate {
         case .Delete:
             tableView.deleteRowsAtIndexPaths([indexPath!], withRowAnimation: .Automatic)
         case .Move:
+            print("Controller did change object: moving cells")
             tableView.moveRowAtIndexPath(indexPath!, toIndexPath: newIndexPath!)
         case .Update:
             tableView.reloadRowsAtIndexPaths([indexPath!], withRowAnimation: .Automatic)

--- a/Coffee Timer/Coffee Timer/TimerListTableViewController.swift
+++ b/Coffee Timer/Coffee Timer/TimerListTableViewController.swift
@@ -128,9 +128,19 @@ class TimerListTableViewController: UITableViewController {
         }
 
         // Disable the delegate when saving the Core Data changes: the cells are
-        // already in the correct state at this point.
+        // already in the correct positions at this point.
         fetchedResultsController.delegate = nil
+        
+        // Save the managed object context, then perform a fetch so that the objects within
+        // the fetchedResultsController are in the right place.
         appDelegate().coreDataStack.save()
+        do {
+            try fetchedResultsController.performFetch()
+        } catch {
+            print("Error fetching: \(error)")
+        }
+        
+        // Reassign the delegate so that changes will be tracked again.
         fetchedResultsController.delegate = self
     }
 


### PR DESCRIPTION
There are some weird UI glitches which occur currently - see [this screen recording](https://vid.me/xBxy). Additionally, the userReordingCells boolean is not being used correctly. Things work much better if the fetchedresultscontroller delegate is disabled whilst rows are being moved.
